### PR TITLE
Add separate table for briefings

### DIFF
--- a/app/Console/Commands/StoreBriefings.php
+++ b/app/Console/Commands/StoreBriefings.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use App\Models\Missions\Mission;
+use Illuminate\Support\Facades\Storage;
+
+class StoreBriefings extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'archub:store_briefings';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Store briefings';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        foreach (Mission::all() as $mission) {
+            $briefingsArray = json_decode($mission->briefings);
+            $mission->storeBriefings($briefingsArray);
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -16,6 +16,7 @@ class Kernel extends ConsoleKernel
         Commands\RenameModes::class,
         Commands\MigrateOldApps::class,
         Commands\ConvertIdToRevisions::class,
+        Commands\StoreBriefings::class,
     ];
 
     /**

--- a/app/Http/Controllers/Missions/MissionController.php
+++ b/app/Http/Controllers/Missions/MissionController.php
@@ -237,7 +237,8 @@ class MissionController extends Controller
             return;
         }
 
-        $mission->lockBriefing($request->faction, $request->locked);
+        $locked = $request->locked == "1" ? true : false;
+        $mission->lockBriefing($request->faction, $locked);
     }
 
     public function orbat(Request $request)

--- a/app/Models/Missions/MissionBriefing.php
+++ b/app/Models/Missions/MissionBriefing.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models\Missions;
+
+use Illuminate\Database\Eloquent\Model;
+
+class MissionBriefing extends Model
+{
+    protected $fillable = [
+        'mission_id',
+        'name',
+        'locked',
+        'sections',
+    ];
+
+    protected $casts = [
+        'sections' => 'array',
+    ];
+
+    public function mission()
+    {
+        return $this->belongsTo(Mission::class);
+    }
+}

--- a/database/migrations/2022_09_25_162813_add_mission_briefings_table.php
+++ b/database/migrations/2022_09_25_162813_add_mission_briefings_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Models\Missions\Mission;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+
+        Schema::create('mission_briefings', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->foreignIdFor(Mission::class);
+            $table->string('name');
+            $table->boolean('locked')->default(false);
+            $table->json('sections');
+
+            $table->unique(['mission_id', 'name']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('mission_briefings');
+    }
+};

--- a/resources/views/missions/briefing.blade.php
+++ b/resources/views/missions/briefing.blade.php
@@ -1,59 +1,53 @@
 @if ($mission->briefingLocked($faction))
-    <div class="alert alert-warning float-start w-100 mt-2" role="alert">
-        <strong>This briefing is locked!</strong> Only the mission maker and testers can see it.
-    </div>
+<div class="alert alert-warning float-start w-100 mt-2" role="alert">
+    <strong>This briefing is locked!</strong> Only the mission maker and testers can see it.
+</div>
 @endif
 
 @can('manage-mission', $mission)
-    <script>
-        $(document).ready(function(e) {
-            $('#lock-briefing').click(function(event) {
-                var caller = $(this);
-                var id = caller.data('id');
-                var faction = caller.data('faction');
-                var locked = caller.data('locked');
+<script>
+    $(document).ready(function(e) {
+        $('#lock-briefing').click(function(event) {
+            var caller = $(this);
+            var id = caller.data('id');
+            var faction = caller.data('faction');
+            var locked = caller.data('locked');
 
-                $.ajax({
-                    type: 'POST',
-                    url: '{{ url('/hub/missions/briefing/update') }}',
-                    data: {
-                        'mission_id': id,
-                        'faction': faction,
-                        'locked': locked
-                    },
-                    success: function(data) {
-                        caller.data('locked', (locked == 1) ? 0 : 1);
-                        caller.html(
-                            (locked == 1) ?
-                            'Unlock {{ $mission->factions[$faction] }} Briefing' :
-                            'Lock {{ $mission->factions[$faction] }} Briefing'
-                        );
-                    }
-                });
-
-                event.preventDefault();
+            $.ajax({
+                type: 'POST',
+                url: "{{ url('/hub/missions/briefing/update') }}",
+                data: {
+                    'mission_id': id,
+                    'faction': faction,
+                    'locked': locked
+                },
+                success: function(data) {
+                    caller.data('locked', (locked == 1) ? 0 : 1);
+                    caller.html(
+                        (locked == 1) ?
+                        'Unlock {{ $faction }}' :
+                        'Lock {{ $faction }}'
+                    );
+                }
             });
-        });
-    </script>
 
-    <div class="float-start w-100">
-        <a
-            href="javascript:void(0)"
-            class="btn btn-primary float-end mt-3"
-            id="lock-briefing"
-            data-faction="{{ $faction }}"
-            data-id="{{ $mission->id }}"
-            data-locked="{{ ($mission->briefingLocked($faction)) ? '0' : '1' }}">
-            {{ ($mission->briefingLocked($faction)) ? 'Unlock' : 'Lock' }} {{ $mission->factions[$faction] }} Briefing
-        </a>
-    </div>
+            event.preventDefault();
+        });
+    });
+</script>
+
+<div class="float-start w-100">
+    <a href="javascript:void(0)" class="btn btn-primary float-end mt-3" id="lock-briefing" data-faction="{{ $faction }}" data-id="{{ $mission->id }}" data-locked="{{ ($mission->briefingLocked($faction)) ? '0' : '1' }}">
+        {{ ($mission->briefingLocked($faction)) ? 'Unlock' : 'Lock' }} {{ $faction }}
+    </a>
+</div>
 @endcan
 
 <div class="float-start w-100 mt-3">
     @foreach ($mission->briefing($faction) as $subject)
-        <h5>{{ $subject->title }}</h5>       
+    <h5>{{ $subject->title }}</h5>
 
-        {!! $subject->paragraphs !!}
-        <br/><br/>
+    {!! $subject->paragraphs !!}
+    <br /><br />
     @endforeach
 </div>

--- a/resources/views/missions/show/briefing.blade.php
+++ b/resources/views/missions/show/briefing.blade.php
@@ -9,9 +9,9 @@
 
             $.ajax({
                 type: 'POST',
-                url: '{{ url('/hub/missions/briefing') }}',
+                url: "{{ url('/hub/missions/briefing')}} ",
                 data: {
-                    mission_id: {{ $mission->id }},
+                    mission_id: "{{ $mission->id }}",
                     faction: faction
                 },
                 success: function(data) {
@@ -30,13 +30,10 @@
 
 <div class="mission-briefing">
     <div class="mission-briefing-nav">
-        @foreach ($mission->briefingFactions() as $item)
-            <a
-                href="javascript:void(0)"
-                class="ripple"
-                data-faction="{{ $item->faction }}">
-                {{ $item->name }}
-            </a>
+        @foreach ($mission->briefingFactions() as $briefing)
+        <a href="javascript:void(0)" class="ripple" data-faction="{{ $briefing->name }}">
+            {{ $briefing->name }}
+        </a>
         @endforeach
     </div>
 


### PR DESCRIPTION
It's a pretty hacky implementation because I want to touch the front end as little as possible, but this allows us to have any number of briefings whatever faction they are and to set individual locks for them

I've left in all the `locked_x_briefing` and `briefings` columns in the missions table in case we need to revert the changes for whatever reason - I'll remove them once archub v2 is fully released

![image](https://user-images.githubusercontent.com/28692063/192159153-049aea9d-8cd1-4500-acd9-cf007fefacd5.png)
